### PR TITLE
removed typo in param setting for GPU in featurewiz.py

### DIFF
--- a/featurewiz/featurewiz.py
+++ b/featurewiz/featurewiz.py
@@ -757,9 +757,9 @@ def featurewiz(dataname, target, corr_limit=0.8, verbose=0, sep=",", header=0,
         tree_method = 'gpu_hist'
         param['nthread'] = -1
         param['tree_method'] = 'gpu_hist'
-        params['eta'] = 0.01
-        params['subsample'] = 0.5
-        params['grow_policy'] = 'depthwise' # 'lossguide' # 
+        param['eta'] = 0.01
+        param['subsample'] = 0.5
+        param['grow_policy'] = 'depthwise' # 'lossguide' # 
         param['n_estimators'] = n_estimators
         param['max_depth'] = max_depth
         param['max_leaves'] = 0


### PR DESCRIPTION
#### Description
Fixes #72 by removing typos in XGBoost GPU param setting in [featurewiz.py](https://github.com/AutoViML/featurewiz/blob/32368b4/featurewiz/featurewiz.py)


#### Expected behavior
`FeatureWiz`'s `fit_transform` method will not result in the error referenced in #72


#### How to test
Run [examples/FeatureWiz_Test.ipynb](https://github.com/AutoViML/featurewiz/blob/32368b4/examples/FeatureWiz_Test.ipynb) with an active GPU