### PR TITLE
Fix dropping columns with zero var in transform

### DIFF
--- a/featurewiz/featurewiz.py
+++ b/featurewiz/featurewiz.py
@@ -3329,6 +3329,7 @@ class FeatureWiz(BaseEstimator, TransformerMixin):
             if len(self.cols_zero_variance) > 0:
                 print('    Dropping %d columns due to zero variance...' %len(self.cols_zero_variance))
                 X_sel = X_sel.drop(self.cols_zero_variance, axis=1)
+                df = df.drop(self.cols_zero_variance, axis=1)
             self.numvars = X_sel.columns.tolist()
             if not self.skip_sulov:
                 self.numvars = FE_remove_variables_using_SULOV_method(df, self.numvars, self.model_type, self.targets,


### PR DESCRIPTION
I have added one line in transform()
```
#### This is where you need to drop columns that have zero variance ######
self.cols_zero_variance = X_sel.columns[(X_sel.var()==0)]
if len(self.cols_zero_variance) > 0:
        print('    Dropping %d columns due to zero variance...' %len(self.cols_zero_variance))
        X_sel = X_sel.drop(self.cols_zero_variance, axis=1)
+        df = df.drop(self.cols_zero_variance, axis=1)
```

In the subsequent steps, feature selection using Sulov and XGBoost is performed on the df.
If ```df.drop(self.cols_zero_variance, axis=1)``` is not executed, there is a possibility that features not present in X_sel will be selected, which could lead to a KeyError when ```return X_sel[self.features], y_sel``` is executed.

